### PR TITLE
Fixed bug where NumericDate was not formatted correctly

### DIFF
--- a/jose/json/circe/src/black/door/jose/json/circe/jwt/JwtJsonSupport.scala
+++ b/jose/json/circe/src/black/door/jose/json/circe/jwt/JwtJsonSupport.scala
@@ -1,5 +1,7 @@
 package black.door.jose.json.circe.jwt
 
+import java.time.Instant
+
 import black.door.jose.jwt.Claims
 import io.circe.{Decoder, Encoder, HCursor, Json}
 import io.circe.syntax._
@@ -8,6 +10,11 @@ import io.circe.generic.semiauto._
 
 trait JwtJsonSupport {
   private val unregisteredObjectKey = "unregistered"
+
+  implicit private[this] val instantEncoder: Encoder[Instant] =
+    Encoder.encodeLong.contramap[Instant](_.getEpochSecond)
+  implicit private[this] val instantDecoder: Decoder[Instant] =
+    Decoder.decodeLong.map(Instant.ofEpochSecond)
 
   implicit val unitDecoder: Decoder[Unit] = new Decoder[Unit] {
     final def apply(c: HCursor): Decoder.Result[Unit] = Right(())

--- a/jose/json/play/src/black/door/jose/json/playjson/jwt/JwtJsonSupport.scala
+++ b/jose/json/play/src/black/door/jose/json/playjson/jwt/JwtJsonSupport.scala
@@ -1,5 +1,7 @@
 package black.door.jose.json.playjson.jwt
 
+import java.time.Instant
+
 import black.door.jose.jwt.Claims
 import black.door.jose.json.playjson._
 import play.api.libs.json._
@@ -10,6 +12,11 @@ trait JwtJsonSupport {
 
   implicit val unitReads  = Reads[Unit](_ => JsSuccess(Unit))
   implicit val unitWrites = OWrites[Unit](_ => JsObject.empty)
+
+  implicit private[this] val instantFormat = Format[Instant](
+    implicitly[Reads[Long]].map(Instant.ofEpochSecond),
+    Writes[Instant](inst => JsNumber(inst.getEpochSecond))
+  )
 
   private val unitClaimsReads = Json.reads[Claims[Unit]]
   private val unregisteredInjector = Reads(
@@ -43,4 +50,5 @@ trait JwtJsonSupport {
   implicit def claimsDeserializer[C](implicit r: Reads[Claims[C]]) =
     jsonDeserializer[Claims[C]]
 }
+
 object JwtJsonSupport extends JwtJsonSupport


### PR DESCRIPTION
NumericDate fields in JWT claims weren't formatted as epoch seconds. Now they are.