### PR TITLE
Fix a concurrency issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ fabric.properties
 .metals
 .vscode
 .coursier
+.bsp
+
+.DS_Store

--- a/jose/src/black/door/jose/jwa/RSAlg.scala
+++ b/jose/src/black/door/jose/jwa/RSAlg.scala
@@ -7,7 +7,7 @@ import black.door.jose.jwk.RsaPublicKey
 
 sealed case class RSAlg(hashBits: Int) extends SignatureAlgorithm {
   val alg          = s"RS$hashBits"
-  val jcaSignature = Signature.getInstance(s"SHA${hashBits}withRSA")
+  def jcaSignature = Signature.getInstance(s"SHA${hashBits}withRSA")
 
   val validate = {
     case (key: RsaPublicKey, header, signingInput, signature) if header.alg == alg =>


### PR DESCRIPTION
Concurrent calls to `Jwt.validate` will often fail because of the use of a thread-unsafe instance from different threads.

This change ensures that `Signature` instances are not concurrently used between threads, by allocating a new one for each RsaAlg validate call.

```
java.security.Signature instances are not thread-safe.

Key points:

- The Signature object holds mutable internal state (e.g., initialized-for-sign/verify, accumulated data via update(...), etc.).
- The JCA/JDK docs and common practice assume one Signature instance per thread / per operation.
- You must not call update/sign/verify on the same instance concurrently from multiple threads.
```